### PR TITLE
Fix the parameter mapping complexity

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -65,6 +65,7 @@
 #include "clang/Sema/Redeclaration.h"
 #include "clang/Sema/Scope.h"
 #include "clang/Sema/SemaBase.h"
+#include "clang/Sema/SemaConcept.h"
 #include "clang/Sema/TypoCorrection.h"
 #include "clang/Sema/Weak.h"
 #include "llvm/ADT/APInt.h"
@@ -14901,8 +14902,6 @@ public:
       const NamedDecl *D1, ArrayRef<AssociatedConstraint> AC1,
       const NamedDecl *D2, ArrayRef<AssociatedConstraint> AC2);
 
-  llvm::DenseMap<unsigned, MutableArrayRef<TemplateArgumentLoc>>
-      ParameterMappingCache;
 private:
   /// Caches pairs of template-like decls whose associated constraints were
   /// checked for subsumption and whether or not the first's constraints did in

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -14901,6 +14901,8 @@ public:
       const NamedDecl *D1, ArrayRef<AssociatedConstraint> AC1,
       const NamedDecl *D2, ArrayRef<AssociatedConstraint> AC2);
 
+  llvm::DenseMap<unsigned, MutableArrayRef<TemplateArgumentLoc>>
+      ParameterMappingCache;
 private:
   /// Caches pairs of template-like decls whose associated constraints were
   /// checked for subsumption and whether or not the first's constraints did in

--- a/clang/include/clang/Sema/SemaConcept.h
+++ b/clang/include/clang/Sema/SemaConcept.h
@@ -89,6 +89,9 @@ protected:
 
   struct ConceptIdBits : AtomicBits {
     NormalizedConstraint *Sub;
+
+    // Only used for parameter mapping.
+    const ConceptSpecializationExpr *CSE;
   };
 
   struct CompoundBits {
@@ -138,13 +141,15 @@ protected:
   NormalizedConstraint(const ConceptReference *ConceptId,
                        const NamedDecl *ConstraintDecl,
                        NormalizedConstraint *SubConstraint,
+                       const ConceptSpecializationExpr *CSE,
                        UnsignedOrNone PackIndex)
       : ConceptId{{llvm::to_underlying(ConstraintKind::ConceptId),
                    /*Placeholder=*/0, PackIndex.toInternalRepresentation(),
                    /*Indexes=*/{},
                    /*Args=*/nullptr, /*ParamList=*/nullptr, ConceptId,
                    ConstraintDecl},
-                  SubConstraint} {}
+                  SubConstraint,
+                  CSE} {}
 
   NormalizedConstraint(NormalizedConstraint *LHS, CompoundConstraintKind CCK,
                        NormalizedConstraint *RHS)
@@ -357,9 +362,14 @@ public:
                                      const ConceptReference *ConceptId,
                                      NormalizedConstraint *SubConstraint,
                                      const NamedDecl *ConstraintDecl,
+                                     const ConceptSpecializationExpr *CSE,
                                      UnsignedOrNone PackIndex) {
     return new (Ctx) ConceptIdConstraint(ConceptId, ConstraintDecl,
-                                         SubConstraint, PackIndex);
+                                         SubConstraint, CSE, PackIndex);
+  }
+
+  const ConceptSpecializationExpr *getConceptSpecializationExpr() const {
+    return ConceptId.CSE;
   }
 
   const ConceptReference *getConceptId() const {

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -35,6 +35,8 @@
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/Timer.h"
+#include "llvm/Support/WithColor.h"
 #include <cstddef>
 #include <optional>
 
@@ -390,16 +392,23 @@ SubstitutionInTemplateArguments(
         Constraint.mappingOccurenceList();
     SubstitutedOuterMost =
         llvm::to_vector_of<TemplateArgument>(MLTAL.getOutermost());
+    unsigned Offset = 0;
     for (unsigned I = 0, MappedIndex = 0; I < Used.size(); I++) {
       TemplateArgument Arg;
       if (Used[I])
         Arg = S.Context.getCanonicalTemplateArgument(
             CTAI.SugaredConverted[MappedIndex++]);
-      if (I < SubstitutedOuterMost.size())
+      if (I < SubstitutedOuterMost.size()) {
         SubstitutedOuterMost[I] = Arg;
-      else
+        Offset = I + 1;
+      } else {
         SubstitutedOuterMost.push_back(Arg);
+        Offset = SubstitutedOuterMost.size();
+      }
     }
+    if (Offset < SubstitutedOuterMost.size())
+      SubstitutedOuterMost.erase(SubstitutedOuterMost.begin() + Offset);
+
     MLTAL.replaceOutermostTemplateArguments(
         const_cast<NamedDecl *>(Constraint.getConstraintDecl()),
         SubstitutedOuterMost);
@@ -765,7 +774,8 @@ static bool CheckConstraintSatisfaction(
   if (TopLevelConceptId) {
     C = ConceptIdConstraint::Create(S.getASTContext(), TopLevelConceptId,
                                     const_cast<NormalizedConstraint *>(C),
-                                    Template, S.ArgPackSubstIndex);
+                                    Template, /*CSE=*/nullptr,
+                                    S.ArgPackSubstIndex);
   }
 
   return !calculateConstraintSatisfaction(
@@ -1535,27 +1545,6 @@ void Sema::DiagnoseUnsatisfiedConstraint(
                                   ConstraintExpr->getBeginLoc(), First);
 }
 
-const NormalizedConstraint *Sema::getNormalizedAssociatedConstraints(
-    ConstrainedDeclOrNestedRequirement ConstrainedDeclOrNestedReq,
-    ArrayRef<AssociatedConstraint> AssociatedConstraints) {
-  if (!ConstrainedDeclOrNestedReq)
-    return NormalizedConstraint::fromAssociatedConstraints(
-        *this, nullptr, AssociatedConstraints);
-
-  // FIXME: ConstrainedDeclOrNestedReq is never a NestedRequirement!
-  const NamedDecl *ND =
-      ConstrainedDeclOrNestedReq.dyn_cast<const NamedDecl *>();
-  auto CacheEntry = NormalizationCache.find(ConstrainedDeclOrNestedReq);
-  if (CacheEntry == NormalizationCache.end()) {
-    auto *Normalized = NormalizedConstraint::fromAssociatedConstraints(
-        *this, ND, AssociatedConstraints);
-    CacheEntry =
-        NormalizationCache.try_emplace(ConstrainedDeclOrNestedReq, Normalized)
-            .first;
-  }
-  return CacheEntry->second;
-}
-
 static bool
 substituteParameterMappings(Sema &S, NormalizedConstraint &N,
                             const MultiLevelTemplateArgumentList &MLTAL,
@@ -1626,30 +1615,6 @@ substituteParameterMappings(Sema &S, NormalizedConstraintWithParamMapping &N,
   if (Inst.isInvalid())
     return true;
 
-  unsigned Hash;
-  llvm::FoldingSetNodeID ID;
-  auto &Context = S.getASTContext();
-  if (N.getKind() == NormalizedConstraint::ConstraintKind::ConceptId) {
-    ID.AddPointer(static_cast<ConceptIdConstraint &>(N)
-                      .getConceptId()
-                      ->getNamedConcept()
-                      ->getCanonicalDecl());
-    for (auto &ArgLoc : static_cast<ConceptIdConstraint &>(N)
-                            .getConceptId()
-                            ->getTemplateArgsAsWritten()
-                            ->arguments())
-      ArgLoc.getArgument().Profile(ID, Context);
-
-    Hash = ID.ComputeHash();
-    if (auto Iter = S.ParameterMappingCache.find(Hash);
-        Iter != S.ParameterMappingCache.end()) {
-      N.updateParameterMapping(N.mappingOccurenceList(), Iter->second,
-                              N.getUsedTemplateParamList());
-      return false;
-    }
-  }
-  // FIXME: Cache for atomic constraints.
-
   // TransformTemplateArguments is unable to preserve the source location of a
   // pack. The SourceLocation is necessary for the instantiation location.
   // FIXME: The BaseLoc will be used as the location of the pack expansion,
@@ -1683,8 +1648,6 @@ substituteParameterMappings(Sema &S, NormalizedConstraintWithParamMapping &N,
                                                CTAI.SugaredConverted.size());
   N.updateParameterMapping(N.mappingOccurenceList(), Mapping,
                            N.getUsedTemplateParamList());
-  if (N.getKind() == NormalizedConstraint::ConstraintKind::ConceptId)
-    S.ParameterMappingCache.insert({Hash, Mapping});
   return false;
 }
 
@@ -1692,14 +1655,39 @@ static bool
 substituteParameterMappings(Sema &S, ConceptIdConstraint &N,
                             const MultiLevelTemplateArgumentList &MLTAL,
                             const ASTTemplateArgumentListInfo *ArgsAsWritten) {
-
+  assert(N.getConstraintDecl());
+#if 0
+  return substituteParameterMappings(
+      S, static_cast<NormalizedConstraintWithParamMapping &>(N), MLTAL,
+      ArgsAsWritten);
+#else
+  auto TemplateArgs = MLTAL;
   if (N.getConstraintDecl()) {
-    substituteParameterMappings(
-        S, static_cast<NormalizedConstraintWithParamMapping &>(N), MLTAL,
-        ArgsAsWritten);
+    if (substituteParameterMappings(
+            S, static_cast<NormalizedConstraintWithParamMapping &>(N),
+            TemplateArgs, ArgsAsWritten))
+      return true;
+    auto *CSE = N.getConceptSpecializationExpr();
+    assert(CSE);
+    TemplateArgumentListInfo Out;
+    assert(!N.getBeginLoc().isInvalid());
+    if (S.SubstTemplateArgumentsInParameterMapping(
+            CSE->getTemplateArgsAsWritten()->arguments(), N.getBeginLoc(),
+            MLTAL, Out))
+      return true;
+    Sema::CheckTemplateArgumentInfo CTAI;
+    if (S.CheckTemplateArgumentList(CSE->getNamedConcept(),
+                                CSE->getConceptNameInfo().getLoc(), Out,
+                                /*DefaultArgs=*/{},
+                                /*PartialTemplateArgs=*/false, CTAI,
+                                /*UpdateArgsWithConversions=*/false))
+      return true;
+    TemplateArgs.replaceOutermostTemplateArguments(
+        TemplateArgs.getAssociatedDecl(0).first, CTAI.CanonicalConverted);
   }
-  return substituteParameterMappings(S, N.getNormalizedConstraint(), MLTAL,
-                                     ArgsAsWritten);
+  return substituteParameterMappings(S, N.getNormalizedConstraint(),
+                                     TemplateArgs, ArgsAsWritten);
+#endif
 }
 
 static bool
@@ -1742,8 +1730,38 @@ static bool substituteParameterMappings(Sema &S, NormalizedConstraint &N,
   // Don't build Subst* nodes to model lambda expressions.
   // The transform of Subst* is oblivious to the lambda type.
   MLTAL.setKind(TemplateSubstitutionKind::Rewrite);
+  Sema::InstantiatingTemplate Inst(
+      S, N.getBeginLoc(),
+      Sema::InstantiatingTemplate::ParameterMappingSubstitution{},
+      CSE->getNamedConcept(), {N.getBeginLoc(), N.getEndLoc()});
+  if (Inst.isInvalid())
+    return true;
+
   return substituteParameterMappings(S, N, MLTAL,
                                      CSE->getTemplateArgsAsWritten());
+}
+
+static bool substituteParameterMappings(Sema &S, NormalizedConstraint &N) {
+  switch (N.getKind()) {
+  case NormalizedConstraint::ConstraintKind::Atomic:
+    return false;
+  case NormalizedConstraint::ConstraintKind::FoldExpanded: {
+    Sema::ArgPackSubstIndexRAII _(S, std::nullopt);
+    return substituteParameterMappings(
+        S, static_cast<FoldExpandedConstraint &>(N).getNormalizedPattern());
+  }
+  case NormalizedConstraint::ConstraintKind::ConceptId: {
+    auto &CC = static_cast<ConceptIdConstraint &>(N);
+    return substituteParameterMappings(S, CC.getNormalizedConstraint(),
+                                       CC.getConceptSpecializationExpr());
+  }
+  case NormalizedConstraint::ConstraintKind::Compound: {
+    auto &Compound = static_cast<CompoundConstraint &>(N);
+    if (substituteParameterMappings(S, Compound.getLHS()))
+      return true;
+    return substituteParameterMappings(S, Compound.getRHS());
+  }
+  }
 }
 
 NormalizedConstraint *NormalizedConstraint::fromAssociatedConstraints(
@@ -1824,11 +1842,11 @@ NormalizedConstraint *NormalizedConstraint::fromConstraintExpr(
       if (!SubNF)
         return nullptr;
     }
-    if (substituteParameterMappings(S, *SubNF, CSE))
-      return nullptr;
+    // if (substituteParameterMappings(S, *SubNF, CSE))
+    //   return nullptr;
 
     return ConceptIdConstraint::Create(
-        S.getASTContext(), CSE->getConceptReference(), SubNF, D, SubstIndex);
+        S.getASTContext(), CSE->getConceptReference(), SubNF, D, CSE, SubstIndex);
 
   } else if (auto *FE = dyn_cast<const CXXFoldExpr>(E);
              FE && S.getLangOpts().CPlusPlus26 &&
@@ -1868,6 +1886,29 @@ NormalizedConstraint *NormalizedConstraint::fromConstraintExpr(
                                           Kind, Sub);
   }
   return AtomicConstraint::Create(S.getASTContext(), E, D, SubstIndex);
+}
+
+const NormalizedConstraint *Sema::getNormalizedAssociatedConstraints(
+    ConstrainedDeclOrNestedRequirement ConstrainedDeclOrNestedReq,
+    ArrayRef<AssociatedConstraint> AssociatedConstraints) {
+  if (!ConstrainedDeclOrNestedReq)
+    return NormalizedConstraint::fromAssociatedConstraints(
+        *this, nullptr, AssociatedConstraints);
+
+  // FIXME: ConstrainedDeclOrNestedReq is never a NestedRequirement!
+  const NamedDecl *ND =
+      ConstrainedDeclOrNestedReq.dyn_cast<const NamedDecl *>();
+  auto CacheEntry = NormalizationCache.find(ConstrainedDeclOrNestedReq);
+  if (CacheEntry == NormalizationCache.end()) {
+    auto *Normalized = NormalizedConstraint::fromAssociatedConstraints(
+        *this, ND, AssociatedConstraints);
+    CacheEntry =
+        NormalizationCache.try_emplace(ConstrainedDeclOrNestedReq, Normalized)
+            .first;
+    if (!Normalized || substituteParameterMappings(*this, *Normalized))
+      return nullptr;
+  }
+  return CacheEntry->second;
 }
 
 bool FoldExpandedConstraint::AreCompatibleForSubsumption(

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -1542,6 +1542,7 @@ const NormalizedConstraint *Sema::getNormalizedAssociatedConstraints(
     return NormalizedConstraint::fromAssociatedConstraints(
         *this, nullptr, AssociatedConstraints);
 
+  // FIXME: ConstrainedDeclOrNestedReq is never a NestedRequirement!
   const NamedDecl *ND =
       ConstrainedDeclOrNestedReq.dyn_cast<const NamedDecl *>();
   auto CacheEntry = NormalizationCache.find(ConstrainedDeclOrNestedReq);
@@ -1624,6 +1625,31 @@ substituteParameterMappings(Sema &S, NormalizedConstraintWithParamMapping &N,
       {InstLocBegin, InstLocEnd});
   if (Inst.isInvalid())
     return true;
+
+  unsigned Hash;
+  llvm::FoldingSetNodeID ID;
+  auto &Context = S.getASTContext();
+  if (N.getKind() == NormalizedConstraint::ConstraintKind::ConceptId) {
+    ID.AddPointer(static_cast<ConceptIdConstraint &>(N)
+                      .getConceptId()
+                      ->getNamedConcept()
+                      ->getCanonicalDecl());
+    for (auto &ArgLoc : static_cast<ConceptIdConstraint &>(N)
+                            .getConceptId()
+                            ->getTemplateArgsAsWritten()
+                            ->arguments())
+      ArgLoc.getArgument().Profile(ID, Context);
+
+    Hash = ID.ComputeHash();
+    if (auto Iter = S.ParameterMappingCache.find(Hash);
+        Iter != S.ParameterMappingCache.end()) {
+      N.updateParameterMapping(N.mappingOccurenceList(), Iter->second,
+                              N.getUsedTemplateParamList());
+      return false;
+    }
+  }
+  // FIXME: Cache for atomic constraints.
+
   // TransformTemplateArguments is unable to preserve the source location of a
   // pack. The SourceLocation is necessary for the instantiation location.
   // FIXME: The BaseLoc will be used as the location of the pack expansion,
@@ -1653,10 +1679,12 @@ substituteParameterMappings(Sema &S, NormalizedConstraintWithParamMapping &N,
   // N.updateParameterMapping(
   //     N.mappingOccurenceList(),
   //     MutableArrayRef<TemplateArgumentLoc>(TempArgs, SubstArgs.size()));
-  N.updateParameterMapping(N.mappingOccurenceList(),
-                           MutableArrayRef<TemplateArgumentLoc>(
-                               TempArgs, CTAI.SugaredConverted.size()),
+  MutableArrayRef<TemplateArgumentLoc> Mapping(TempArgs,
+                                               CTAI.SugaredConverted.size());
+  N.updateParameterMapping(N.mappingOccurenceList(), Mapping,
                            N.getUsedTemplateParamList());
+  if (N.getKind() == NormalizedConstraint::ConstraintKind::ConceptId)
+    S.ParameterMappingCache.insert({Hash, Mapping});
   return false;
 }
 

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -17,6 +17,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/AST/DependenceFlags.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprConcepts.h"
 #include "clang/AST/TemplateBase.h"
@@ -593,6 +594,19 @@ static bool calculateConstraintSatisfaction(
     SourceLocation TemplateNameLoc, const MultiLevelTemplateArgumentList &MLTAL,
     ConstraintSatisfaction &Satisfaction,
     UnsignedOrNone PackSubstitutionIndex) {
+
+  // If the expression has been calculated, e.g. when we are in a nested
+  // requirement, do not compute it repeatedly.
+  if (auto *Expr = Constraint.getConceptSpecializationExpr();
+      Expr && Expr->getDependence() == ExprDependence::None) {
+    auto &Calculated = Expr->getSatisfaction();
+    Satisfaction.ContainsErrors = Calculated.ContainsErrors;
+    Satisfaction.IsSatisfied = Calculated.IsSatisfied;
+    Satisfaction.Details.insert(Satisfaction.Details.end(),
+                                Calculated.records().begin(),
+                                Calculated.records().end());
+    return !Satisfaction.ContainsErrors;
+  }
 
   Sema::ContextRAII CurContext(
       S, Constraint.getConceptId()->getNamedConcept()->getDeclContext(),
@@ -1581,6 +1595,8 @@ substituteParameterMappings(Sema &S, NormalizedConstraintWithParamMapping &N,
       SourceLocation Loc = ArgsAsWritten->NumTemplateArgs > I
                                ? ArgsAsWritten->arguments()[I].getLocation()
                                : SourceLocation();
+      // FIXME: Investigate when we couldn't preserve the SourceLoc. What shall we do??
+      // assert(Loc.isValid());
       if (OccurringIndices[I]) {
         NamedDecl *Param = TemplateParams->begin()[I];
         new (&(TempArgs)[J])
@@ -1637,6 +1653,7 @@ substituteParameterMappings(Sema &S, NormalizedConstraintWithParamMapping &N,
     // If this is an empty pack, we have no corresponding SubstArgs.
     if (I < SubstArgs.size())
       Loc = SubstArgs.arguments()[I].getLocation();
+    // assert(Loc.isValid());
     TempArgs[I] = S.getTrivialTemplateArgumentLoc(CTAI.SugaredConverted[I],
                                                   QualType(), Loc);
   }
@@ -1671,9 +1688,29 @@ substituteParameterMappings(Sema &S, ConceptIdConstraint &N,
     assert(CSE);
     TemplateArgumentListInfo Out;
     assert(!N.getBeginLoc().isInvalid());
-    if (S.SubstTemplateArgumentsInParameterMapping(
-            CSE->getTemplateArgsAsWritten()->arguments(), N.getBeginLoc(),
-            MLTAL, Out))
+    // TransformTemplateArguments is unable to preserve the source location of a
+    // pack. The SourceLocation is necessary for the instantiation location.
+    // FIXME: The BaseLoc will be used as the location of the pack expansion,
+    // which is wrong.
+    ArgsAsWritten = CSE->getTemplateArgsAsWritten();
+    SourceLocation InstLocBegin =
+        ArgsAsWritten->arguments().empty()
+            ? ArgsAsWritten->getLAngleLoc()
+            : ArgsAsWritten->arguments().front().getSourceRange().getBegin();
+    SourceLocation InstLocEnd =
+        ArgsAsWritten->arguments().empty()
+            ? ArgsAsWritten->getRAngleLoc()
+            : ArgsAsWritten->arguments().front().getSourceRange().getEnd();
+    Sema::InstantiatingTemplate Inst(
+        S, InstLocBegin,
+        Sema::InstantiatingTemplate::ParameterMappingSubstitution{},
+        const_cast<NamedDecl *>(N.getConstraintDecl()),
+        {InstLocBegin, InstLocEnd});
+    if (Inst.isInvalid())
+      return true;
+
+    if (S.SubstTemplateArgumentsInParameterMapping(ArgsAsWritten->arguments(),
+                                                   N.getBeginLoc(), MLTAL, Out))
       return true;
     Sema::CheckTemplateArgumentInfo CTAI;
     if (S.CheckTemplateArgumentList(CSE->getNamedConcept(),

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -3714,10 +3714,6 @@ public:
                                         ParentContext);
   }
 
-  /// Build a new Objective-C boxed expression.
-  ///
-  /// By default, performs semantic analysis to build the new expression.
-  /// Subclasses may override this routine to provide different behavior.
   ExprResult RebuildConceptSpecializationExpr(NestedNameSpecifierLoc NNS,
       SourceLocation TemplateKWLoc, DeclarationNameInfo ConceptNameInfo,
       NamedDecl *FoundDecl, ConceptDecl *NamedConcept,

--- a/clang/test/CXX/temp/temp.constr/temp.constr.normal/p1.cpp
+++ b/clang/test/CXX/temp/temp.constr/temp.constr.normal/p1.cpp
@@ -1,9 +1,11 @@
 // RUN: %clang_cc1 -std=c++2a -x c++ -verify %s
+// FIXME: RUN: %clang_cc1 -std=c++2c -x c++ -verify %s
 
 template<typename T> concept True = true;
 template<typename T> concept Foo = True<T*>;
 template<typename T> concept Bar = Foo<T&>;
 template<typename T> requires Bar<T> struct S { };
+// FIXME: GCC rejects: https://gcc.godbolt.org/z/c9G7G6PTx if the specialization is present.
 template<typename T> requires Bar<T> && true struct S<T> { };
 
 template<typename T> concept True2 = sizeof(T) >= 0;


### PR DESCRIPTION
This helps reduce the time cost of time_zone.cpp from 44s -> 6s. Though it still fails as of now.

The substitution complexity should be O(N) than previous O(N!).

I didn't add/fix any cache mechanism in this patch.

It still needs improvements & investigation, as previous clang only takes 3s to compile.
