### PR TITLE
Fix stdexec regressions

### DIFF
--- a/clang/lib/AST/TemplateBase.cpp
+++ b/clang/lib/AST/TemplateBase.cpp
@@ -606,8 +606,11 @@ TemplateArgumentLoc::TemplateArgumentLoc(ASTContext &Ctx,
       LocInfo(Ctx, TemplateKWLoc, QualifierLoc, TemplateNameLoc, EllipsisLoc) {
   assert(Argument.getKind() == TemplateArgument::Template ||
          Argument.getKind() == TemplateArgument::TemplateExpansion);
-  assert(QualifierLoc.getNestedNameSpecifier() ==
-         Argument.getAsTemplateOrTemplatePattern().getQualifier());
+  // We can't assume QualifierLoc.getNestedNameSpecifier() ==
+  // Argument.getAsTemplateOrTemplatePattern().getQualifier() at this point,
+  // because in template rewriting, we may substitute a DependentTemplateName
+  // (which has a NNSLoc) into a template template parameter (which
+  // doesn't have a NNSLoc).
 }
 
 NestedNameSpecifierLoc TemplateArgumentLoc::getTemplateQualifierLoc() const {

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -306,6 +306,7 @@ public:
 
 namespace {
 
+// FIXME: Convert it to DynamicRecursiveASTVisitor
 class HashParameterMapping : public RecursiveASTVisitor<HashParameterMapping> {
   using inherited = RecursiveASTVisitor<HashParameterMapping>;
   friend inherited;
@@ -387,6 +388,20 @@ public:
   bool TraverseTypeLoc(TypeLoc TL, bool TraverseQualifier = true) {
     // We don't care about TypeLocs. So traverse Types instead.
     return TraverseType(TL.getType(), TraverseQualifier);
+  }
+
+  bool TraverseTagType(const TagType *T, bool TraverseQualifier) {
+    // T's parent can be dependent while T doesn't have any template arguments.
+    // We should have already traversed its qualifier.
+    // FIXME: Add an assert to catch cases where we failed to profile the
+    // concept. assert(!T->isDependentType() && "We missed a case in profiling
+    // concepts!");
+    return true;
+  }
+
+  bool TraverseInjectedClassNameType(InjectedClassNameType *T,
+                                     bool TraverseQualifier) {
+    return TraverseTemplateArguments(T->getTemplateArgs(SemaRef.Context));
   }
 
   bool TraverseTemplateArgument(const TemplateArgument &Arg) {

--- a/clang/test/SemaTemplate/concepts.cpp
+++ b/clang/test/SemaTemplate/concepts.cpp
@@ -1266,3 +1266,25 @@ template <class Tb, class Ub> concept A42b = Void<Tb> || A42<Ub>;
 template <class Tc> concept R42c = A42b<Tc, Tc&>;
 static_assert (R42c<void>);
 }
+
+namespace parameter_mapping_regressions {
+
+namespace case1 {
+
+template <template <class> class> using __meval = struct __q;
+template <template <class> class _Tp>
+concept __mvalid = requires { typename __meval<_Tp>; };
+template <class _Fn>
+concept __minvocable = __mvalid<_Fn::template __f>;
+template <class...> struct __mdefer_;
+template <class _Fn, class... _Args>
+  requires __minvocable<_Fn>
+struct __mdefer_<_Fn, _Args...> {};
+template <class = __q> struct __mtransform {
+  template <class> using __f = int;
+};
+struct __completion_domain_or_none_ : __mdefer_<__mtransform<>> {};
+
+}
+
+}


### PR DESCRIPTION
We may substitute _Fn::template __f (a dependent template name) into a template-template parameter name, when building a parameter mapping.

They can't have the same NNSLoc, so the assertion doesn't hold.

Also we missed a case when profiling the concept, as in InjectedClassNameType.