### PR TITLE
Remove a workaround when building __is_deducible type trait for CTAD guides

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -13583,7 +13583,7 @@ public:
   /// Retrieve the template argument list(s) that should be used to
   /// instantiate the definition of the given declaration.
   ///
-  /// \param ND the declaration for which we are computing template
+  /// \param D the declaration for which we are computing template
   /// instantiation arguments.
   ///
   /// \param DC In the event we don't HAVE a declaration yet, we instead provide
@@ -13615,7 +13615,7 @@ public:
   /// when encountering a specialized member function template, rather than
   /// returning immediately.
   MultiLevelTemplateArgumentList getTemplateInstantiationArgs(
-      const NamedDecl *D, const DeclContext *DC = nullptr, bool Final = false,
+      const Decl *D, const DeclContext *DC = nullptr, bool Final = false,
       std::optional<ArrayRef<TemplateArgument>> Innermost = std::nullopt,
       bool RelativeToPrimary = false, const FunctionDecl *Pattern = nullptr,
       bool ForConstraintInstantiation = false,

--- a/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
+++ b/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
@@ -991,39 +991,6 @@ Expr *buildIsDeducibleConstraint(Sema &SemaRef,
                                  QualType ReturnType,
                                  SmallVector<NamedDecl *> TemplateParams) {
   ASTContext &Context = SemaRef.Context;
-  // Constraint AST nodes must use uninstantiated depth.
-  if (auto *PrimaryTemplate =
-          AliasTemplate->getInstantiatedFromMemberTemplate();
-      PrimaryTemplate && TemplateParams.size() > 0) {
-    LocalInstantiationScope Scope(SemaRef);
-
-    // Adjust the depth for TemplateParams.
-    unsigned AdjustDepth = PrimaryTemplate->getTemplateDepth();
-    SmallVector<TemplateArgument> TransformedTemplateArgs;
-    for (auto *TP : TemplateParams) {
-      // Rebuild any internal references to earlier parameters and reindex
-      // as we go.
-      MultiLevelTemplateArgumentList Args;
-      Args.setKind(TemplateSubstitutionKind::Rewrite);
-      Args.addOuterTemplateArguments(TransformedTemplateArgs);
-      NamedDecl *NewParam = transformTemplateParameter(
-          SemaRef, AliasTemplate->getDeclContext(), TP, Args,
-          /*NewIndex=*/TransformedTemplateArgs.size(),
-          getDepthAndIndex(TP).first + AdjustDepth);
-
-      TemplateArgument NewTemplateArgument =
-          Context.getInjectedTemplateArg(NewParam);
-      TransformedTemplateArgs.push_back(NewTemplateArgument);
-    }
-    // Transformed the ReturnType to restore the uninstantiated depth.
-    MultiLevelTemplateArgumentList Args;
-    Args.setKind(TemplateSubstitutionKind::Rewrite);
-    Args.addOuterTemplateArguments(TransformedTemplateArgs);
-    ReturnType = SemaRef.SubstType(
-        ReturnType, Args, AliasTemplate->getLocation(),
-        Context.DeclarationNames.getCXXDeductionGuideName(AliasTemplate));
-  }
-
   SmallVector<TypeSourceInfo *> IsDeducibleTypeTraitArgs = {
       Context.getTrivialTypeSourceInfo(
           Context.getDeducedTemplateSpecializationType(
@@ -1613,30 +1580,30 @@ TypeAliasTemplateDecl *Sema::BuildAliasForCTADFromTypeTemplateParameter(
   // template-name designates a type template template parameter P, let A be an
   // alias template whose template parameter list is that of P and whose
   // defining-type-id designates the type template template argument with a
-  // simpletemplate-id in which the template-argument-list consists of a list of
-  // identifiers naming each template-parameter of P, with the argument being a
-  // pack expansion if the template-parameter is a pack. A is then used instead
-  // of the original template-name to resolve the placeholder
+  // simple-template-id in which the template-argument-list consists of a list
+  // of identifiers naming each template-parameter of P, with the argument being
+  // a pack expansion if the template-parameter is a pack. A is then used
+  // instead of the original template-name to resolve the placeholder.
 
   LocalInstantiationScope Scope(SemaRef);
 
-  auto &AST = SemaRef.getASTContext();
-  auto *Ctx = CurContext->getParent();
+  auto &AST = getASTContext();
+  auto *Ctx =
+      CurContext->isFileContext() ? CurContext : CurContext->getParent();
 
-  MultiLevelTemplateArgumentList MTAL;
-  if (NamedDecl *Func = dyn_cast<NamedDecl>(CurContext))
-    MTAL = SemaRef.getTemplateInstantiationArgs(Func);
+  MultiLevelTemplateArgumentList MLTAL =
+      getTemplateInstantiationArgs(nullptr, CurContext);
 
   llvm::SmallVector<NamedDecl *> Parameters;
   llvm::SmallVector<TemplateArgument> Args;
   for (NamedDecl *P : D->getTemplateParameters()->asArray()) {
     auto [Depth, Index] = getDepthAndIndex(P);
     NamedDecl *NewParam =
-        transformTemplateParameter(*this, Ctx, P, MTAL, Index, Depth - 1);
+        transformTemplateParameter(*this, Ctx, P, MLTAL, Index, Depth - 1);
     if (!NewParam)
       return nullptr;
     Parameters.push_back(NewParam);
-    Args.push_back(SemaRef.Context.getInjectedTemplateArg(NewParam));
+    Args.push_back(Context.getInjectedTemplateArg(NewParam));
   }
 
   auto *ParamList =
@@ -1646,6 +1613,7 @@ TypeAliasTemplateDecl *Sema::BuildAliasForCTADFromTypeTemplateParameter(
   QualType Type = AST.getCanonicalType(AST.getTemplateSpecializationType(
       ElaboratedTypeKeyword::Class, Replacement, Args, {}));
 
+  // FIXME: Have a flag to distinguish such special type alias declarations.
   auto *Alias = TypeAliasDecl::Create(AST, Ctx, Loc, SourceLocation(), nullptr,
                                       AST.getTrivialTypeSourceInfo(Type));
   Alias->setImplicit(true);

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -54,6 +54,7 @@ struct Response {
   const Decl *NextDecl = nullptr;
   bool IsDone = false;
   bool ClearRelativeToPrimary = true;
+  bool EnableSkipForSpecialization = false;
   static Response Done() {
     Response R;
     R.IsDone = true;
@@ -327,6 +328,11 @@ Response HandleFunction(Sema &SemaRef, const FunctionDecl *Function,
         }
       }
     }
+    if (isa<CXXDeductionGuideDecl>(Function)) {
+      auto Response = Response::UseNextDecl(Function);
+      Response.EnableSkipForSpecialization = true;
+      return Response;
+    }
   }
   // If this is a friend or local declaration and it declares an entity at
   // namespace scope, take arguments from its lexical parent
@@ -486,19 +492,19 @@ Response HandleGenericDeclContext(const Decl *CurDecl) {
 } // namespace
 
 MultiLevelTemplateArgumentList Sema::getTemplateInstantiationArgs(
-    const NamedDecl *ND, const DeclContext *DC, bool Final,
+    const Decl *CurDecl, const DeclContext *DC, bool Final,
     std::optional<ArrayRef<TemplateArgument>> Innermost, bool RelativeToPrimary,
     const FunctionDecl *Pattern, bool ForConstraintInstantiation,
     bool SkipForSpecialization, bool ForDefaultArgumentSubstitution) {
-  assert((ND || DC) && "Can't find arguments for a decl if one isn't provided");
+  assert((CurDecl || DC) &&
+         "Can't find arguments for a decl if one isn't provided");
   // Accumulate the set of template argument lists in this structure.
   MultiLevelTemplateArgumentList Result;
 
   using namespace TemplateInstArgsHelpers;
-  const Decl *CurDecl = ND;
 
   if (Innermost) {
-    Result.addOuterTemplateArguments(const_cast<NamedDecl *>(ND), *Innermost,
+    Result.addOuterTemplateArguments(const_cast<Decl *>(CurDecl), *Innermost,
                                      Final);
     // Populate placeholder template arguments for TemplateTemplateParmDecls.
     // This is essential for the case e.g.
@@ -555,6 +561,8 @@ MultiLevelTemplateArgumentList Sema::getTemplateInstantiationArgs(
       return Result;
     if (R.ClearRelativeToPrimary)
       RelativeToPrimary = false;
+    if (R.EnableSkipForSpecialization)
+      SkipForSpecialization = true;
     assert(R.NextDecl);
     CurDecl = R.NextDecl;
   }

--- a/clang/test/AST/ast-dump-ctad-alias.cpp
+++ b/clang/test/AST/ast-dump-ctad-alias.cpp
@@ -24,7 +24,7 @@ Out2<double>::AInner t(1.0);
 // Verify that the require-clause of alias deduction guide is transformed correctly:
 //   - Occurrence T should be replaced with `int`;
 //   - Occurrence V should be replaced with the Y with depth 1
-//   - Depth of occurrence Y in the __is_deducible constraint should be 1
+//   - Depth of occurrence Y in the __is_deducible constraint should be 0
 //
 // CHECK:      |   `-FunctionTemplateDecl {{.*}} <deduction guide for AInner>
 // CHECK-NEXT: |     |-TemplateTypeParmDecl {{.*}} typename depth 0 index 0 Y
@@ -45,7 +45,7 @@ Out2<double>::AInner t(1.0);
 // CHECK-NEXT: |     |     `-TemplateArgument type 'Y'
 // CHECK-NEXT: |     |       `-SubstTemplateTypeParmType {{.*}} 'Y'
 // CHECK-NEXT: |     |         |-FunctionTemplate {{.*}} '<deduction guide for Inner>'
-// CHECK-NEXT: |     |         `-TemplateTypeParmType {{.*}} 'Y' dependent depth 1 index 0
+// CHECK-NEXT: |     |         `-TemplateTypeParmType {{.*}} 'Y' dependent depth 0 index 0
 // CHECK-NEXT: |     |           `-TemplateTypeParm {{.*}} 'Y'
 // CHECK-NEXT: |     |-CXXDeductionGuideDecl {{.*}} <deduction guide for AInner> 'auto (Y) -> Inner<Y>'
 // CHECK-NEXT: |     | `-ParmVarDecl {{.*}} 'Y'

--- a/clang/test/SemaTemplate/nested-implicit-deduction-guides.cpp
+++ b/clang/test/SemaTemplate/nested-implicit-deduction-guides.cpp
@@ -82,7 +82,7 @@ using NIL = nested_init_list<int>::B<int>;
 // expected-error@+1 {{no viable constructor or deduction guide for deduction of template arguments of 'nested_init_list<int>::concept_fail'}}
 nested_init_list<int>::concept_fail nil_invalid{1, ""};
 // expected-note@#INIT_LIST_INNER_INVALID {{candidate template ignored: constraints not satisfied [with F = const char *]}}
-// expected-note@#INIT_LIST_INNER_INVALID_HEADER {{because 'const char *' does not satisfy 'False'}}
+// expected-note@#INIT_LIST_INNER_INVALID_HEADER {{because 'F' does not satisfy 'False'}}
 // expected-note@#False {{because 'false' evaluated to false}}
 // expected-note@#INIT_LIST_INNER_INVALID {{implicit deduction guide declared as 'template <False F> concept_fail(int, F) -> nested_init_list<int>::concept_fail<F>'}}
 // expected-note@#INIT_LIST_INNER_INVALID {{candidate function template not viable: requires 1 argument, but 2 were provided}}


### PR DESCRIPTION
Also this refactors getTemplateInstantiationArgs a bit, to have it accept Decl* instead of NamedDecl* to avoid unnecessary casts from callers.